### PR TITLE
Add required Github secret. Closes #15. Breaking change, bump to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Realtime staging environments.
 
+## Prerequisites
+
+Node 6.6.0 and greater (security requirement for crypto.timingSafeEqual)
+
 ## Development
 
 Install project dependencies:
@@ -53,7 +57,15 @@ $ ngrok http 3000
 ```
 
 Setup a [test repo](https://github.com/zpnk/hello-world) on GitHub and configure
-a webhook using the ngrok url. Give it access to the "Pull request" event.
+a webhook using the ngrok url. Give it access to the "Pull request" event. You
+also must set a secret. Use this value as your GITHUB_WEBHOOK_SECRET. It should
+be long and you should not share it with anyone.
+
+Now use the same value to set your secret environment variable:
+
+```bash
+$ export GITHUB_WEBHOOK_SECRET=REPLACEME_REPLACEME_REPLACEME_REPLACEME_REPLACEME_REPLACEME_REPLACEME
+```
 
 Open a PR on your repo to trigger the webhook. It will also fire on commits
 pushed to the PR's branch.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stage-ci",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "server.js",
   "license": "MIT",
   "scripts": {

--- a/src/server.js
+++ b/src/server.js
@@ -17,8 +17,17 @@ server.get('/', (request, response) => {
 });
 
 server.post('/', (request, response) => {
-  const {success, ref, sha, name, alias, cloneUrl, setStatus} = github(request.body);
-
+  let result;
+  try {
+    const {headers, body} = request;
+    result = github({headers, body});
+  } catch (error) {
+    if (error.asJson && error.asJson.error && error.asJson.error.type === 'fatal') {
+      response.status(500).send(error.asJson);
+      return;
+    }
+  }
+  const {success, ref, sha, name, alias, cloneUrl, setStatus} = result;
   response.sendStatus((success) ? 200 : 204);
   if (!success) return;
 


### PR DESCRIPTION
This adds a github webhook secret, required checks for env key, bumps to 2.0.0 due to breaking changes. Should be merged in tandem with docs PR at https://github.com/zpnk/stage.now/issues/13