### PR TITLE
Allow for branch names with special url characters

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -87,13 +87,14 @@ function github({headers, body}) {
 
   const {repository, pull_request} = body;
   const {ref, sha} = pull_request.head;
+  const INVALID_URI_CHARACTERS = /\//g;
 
   return {
     ref,
     sha,
     success: true,
     name: repository.full_name,
-    alias: `https://${repository.name.replace(/[^A-Z0-9]/ig, '-')}-${encodeURIComponent(ref)}.now.sh`,
+    alias: `https://${repository.name.replace(/[^A-Z0-9]/ig, '-')}-${ref.replace(INVALID_URI_CHARACTERS, '-')}.now.sh`,
     cloneUrl: url.format(Object.assign(
       url.parse(repository.clone_url),
       {auth: process.env.GITHUB_TOKEN}

--- a/src/core.js
+++ b/src/core.js
@@ -93,7 +93,7 @@ function github({headers, body}) {
     sha,
     success: true,
     name: repository.full_name,
-    alias: `https://${repository.name.replace(/[^A-Z0-9]/ig, '-')}-${ref}.now.sh`,
+    alias: `https://${repository.name.replace(/[^A-Z0-9]/ig, '-')}-${encodeURIComponent(ref)}.now.sh`,
     cloneUrl: url.format(Object.assign(
       url.parse(repository.clone_url),
       {auth: process.env.GITHUB_TOKEN}


### PR DESCRIPTION
Urls would be incorrect if my branch was named `feature/stage`.