### PR TITLE
Adopt Github Deployments

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -21,7 +21,7 @@ const now = (cmd='') => {
 const githubApi = axios.create({
   headers: {
     Authorization: `token ${process.env.GITHUB_TOKEN}`,
-    Accept: 'application/vnd.github.ant-man-preview+json'
+    Accept: 'application/vnd.github.ant-man-preview+json, application/json'
   }
 });
 

--- a/src/core.js
+++ b/src/core.js
@@ -88,8 +88,8 @@ function github({headers, body}) {
 
   const {repository, pull_request} = body;
   const {ref, sha} = pull_request.head;
+  const {deployments_url} = repository;
   const aliasID = `${repository.name.replace(/[^A-Z0-9]/gi, '-')}-pr${pull_request.number}`;
-  const {deployments_url} = pull_request.head.repo;
   let deploymentId;
 
   return {
@@ -99,14 +99,14 @@ function github({headers, body}) {
     name: repository.full_name,
     alias: `https://${aliasID}.now.sh`,
     cloneUrl: url.format(Object.assign(
-      url.parse(repository.clone_url),
+      url.parse(pull_request.head.repo.clone_url),
       {auth: process.env.GITHUB_TOKEN}
     )),
     deploy: async () => {
       // https://developer.github.com/v3/repos/deployments/#create-a-deployment-status
       // https://developer.github.com/changes/2016-04-06-deployment-and-deployment-status-enhancements/
       const result = await githubApi.post(deployments_url, {
-        ref,
+        ref: sha,
         auto_merge: false,
         required_contexts: [],
         transient_environment: true,

--- a/src/core.js
+++ b/src/core.js
@@ -104,10 +104,12 @@ function github({headers, body}) {
     )),
     deploy: async () => {
       // https://developer.github.com/v3/repos/deployments/#create-a-deployment-status
+      // https://developer.github.com/changes/2016-04-06-deployment-and-deployment-status-enhancements/
       const result = await githubApi.post(deployments_url, {
         ref,
         auto_merge: false,
         required_contexts: [],
+        transient_environment: true,
         environment: 'PR staging'
       });
       deploymentId = result.data.id;
@@ -118,7 +120,8 @@ function github({headers, body}) {
         state,
         description,
         environment_url: targetUrl,
-        target_url: targetUrl
+        target_url: targetUrl,
+        auto_inactive: false
       });
     }
   };

--- a/src/core.js
+++ b/src/core.js
@@ -89,7 +89,8 @@ function github({headers, body}) {
   const {repository, pull_request} = body;
   const {ref, sha} = pull_request.head;
   const {deployments_url} = repository;
-  const aliasID = `${repository.name.replace(/[^A-Z0-9]/gi, '-')}-pr${pull_request.number}`;
+  const INVALID_URI_CHARACTERS = /\//g;
+  const aliasID = `${repository.name.replace(/[^A-Z0-9]/gi, '-')}-${ref.replace(INVALID_URI_CHARACTERS, '-')}`;
   let deploymentId;
 
   return {

--- a/src/core.js
+++ b/src/core.js
@@ -103,10 +103,12 @@ function github({headers, body}) {
       {auth: process.env.GITHUB_TOKEN}
     )),
     deploy: async () => {
+      // https://developer.github.com/v3/repos/deployments/#create-a-deployment-status
       const result = await githubApi.post(deployments_url, {
         ref,
         auto_merge: false,
-        environment: 'staging'
+        required_contexts: [],
+        environment: 'PR staging'
       });
       deploymentId = result.data.id;
     },

--- a/src/core.js
+++ b/src/core.js
@@ -20,7 +20,8 @@ const now = (cmd='') => {
 
 const githubApi = axios.create({
   headers: {
-    'Authorization': `token ${process.env.GITHUB_TOKEN}`
+    Authorization: `token ${process.env.GITHUB_TOKEN}`,
+    Accept: 'application/vnd.github.ant-man-preview+json'
   }
 });
 
@@ -114,6 +115,7 @@ function github({headers, body}) {
       return githubApi.post(`${deployments_url}/${deploymentId}/statuses`, {
         state,
         description,
+        environment_url: targetUrl,
         target_url: targetUrl
       });
     }

--- a/src/core.js
+++ b/src/core.js
@@ -87,14 +87,14 @@ function github({headers, body}) {
 
   const {repository, pull_request} = body;
   const {ref, sha} = pull_request.head;
-  const INVALID_URI_CHARACTERS = /\//g;
+  const aliasID = `${repository.name.replace(/[^A-Z0-9]/gi, '-')}-pr${pull_request.number}`;
 
   return {
     ref,
     sha,
     success: true,
     name: repository.full_name,
-    alias: `https://${repository.name.replace(/[^A-Z0-9]/ig, '-')}-${ref.replace(INVALID_URI_CHARACTERS, '-')}.now.sh`,
+    alias: `https://${aliasID}.now.sh`,
     cloneUrl: url.format(Object.assign(
       url.parse(repository.clone_url),
       {auth: process.env.GITHUB_TOKEN}

--- a/src/server.js
+++ b/src/server.js
@@ -43,6 +43,11 @@ server.post('/', (request, response) => {
       await setStatus('success', 'Deployed to Now', alias);
     } catch (error) {
       log.error(error.stack);
+      if (error.response) {
+        log.error(error.response.data.message);
+        log.error(error.response.data.errors);
+        log.error(error.response.data.documentation_url);
+      }
       await setStatus('error', 'Error', alias);
     }
 

--- a/src/server.js
+++ b/src/server.js
@@ -27,7 +27,7 @@ server.post('/', (request, response) => {
       return;
     }
   }
-  const {success, ref, sha, name, alias, cloneUrl, setStatus} = result;
+  const {success, ref, sha, name, alias, cloneUrl, setStatus, deploy} = result;
   response.sendStatus((success) ? 200 : 204);
   if (!success) return;
 
@@ -36,10 +36,11 @@ server.post('/', (request, response) => {
     const localDirectory = path.join(DEPLOY_DIR, name);
 
     try {
+      await deploy();
       await setStatus('pending', 'Staging...');
       await sync(cloneUrl, localDirectory, {ref, checkout: sha});
       await stage(localDirectory, {alias});
-      await setStatus('success', alias, alias);
+      await setStatus('success', 'Deployed to Now', alias);
     } catch (error) {
       log.error(error.stack);
       await setStatus('error', 'Error', alias);


### PR DESCRIPTION
fixes #17 

This was pretty straightforward. Here's an example PR where I was using this: https://github.com/paulirish/hello-world/pull/3#event-1108946827

Pending State:
![image](https://cloud.githubusercontent.com/assets/39191/26757076/e40842b2-4865-11e7-9a3a-d5cf0c64cfe7.png)


Completed:
![image](https://cloud.githubusercontent.com/assets/39191/26757113/29fb46c4-4867-11e7-9ed5-d11c319e322d.png)


And I definitely prefer this setup based on deployments rather than commit statuses. It's very visible, whereas once the commit status's all pass, that gets hidden by Github. 


### Configurability:
* the staging environment word in both states is set by us. (in the 1st screenshot i used "staging" and in the 2nd its "staging on now.sh".)
* there's tooltip text set on the "deployed" link in the Completed state that we can configure
* Interestingly, there's a `description` field in for 1) creating a deployment and 2) updating a pending deployment, but it doesn't appear to affect the user-visible UI. _shrug_


cc @mxstbr 

---

As a driveby I changed the alias from branch ref to PR number. I can see the argument for keeping things as they were, so no big deal if you guys want to revert that. :)
