### PR TITLE
Fix for GitLab deploy failing

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -165,6 +165,8 @@ function gitlab({headers, body} = {}) {
     alias: createAliasUrl(source.name, source_branch),
     cloneUrl: createCloneUrl(source.http_url, `gitlab-ci-token:${GITLAB_TOKEN}`),
     setStatus: (state, description, targetUrl) => {
+      if (state === 'error')
+        state = 'failed';
       log.info(`> Setting GitLab status to "${state}"...`);
       return gitlabApi.post(statuses_url, {
         state,
@@ -172,7 +174,8 @@ function gitlab({headers, body} = {}) {
         target_url: targetUrl,
         context: 'ci/stage-ci'
       });
-    }
+    },
+    deploy: () => {}
   };
 }
 


### PR DESCRIPTION
This fixes #31.

`deploy: () => {}` is a little bit hack-y, but it was the easiest way I could think of resolving the issue.

As stated in #29 — if we had tests, this likely would have been caught before 1.2.0 was deployed, so that should be our next focus ✌️ 