### PR TITLE
Fix Docker deployments 🐳

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,21 @@
-FROM node:7-slim
+FROM node:10-alpine
 
-RUN apt-get -y update && apt-get -y install git
+ENV GITHUB_TOKEN=$GITHUB_TOKEN \
+		GITLAB_TOKEN=$GITLAB_TOKEN \
+		ZEIT_API_TOKEN=$ZEIT_API_TOKEN \
+		GITHUB_WEBHOOK_SECRET=$GITHUB_WEBHOOK_SECRET \
+		GITLAB_WEBHOOK_SECRET=$GITLAB_WEBHOOK_SECRET \
+		PAPERTRAIL_HOST=$PAPERTRAIL_HOST \
+		PAPERTRAIL_PORT=$PAPERTRAIL_PORT \
+		ENVS=$ENVS
+
+ENV NOW_VERSION=11.2.1
+
+RUN apk add --no-cache git
 
 WORKDIR /stage-ci
+
+RUN wget https://github.com/zeit/now-cli/releases/download/${NOW_VERSION}/now-alpine.gz && gunzip now-alpine.gz && mv now-alpine now-cli && chmod +x now-cli
 
 COPY package.json .
 RUN npm install --production

--- a/src/core.js
+++ b/src/core.js
@@ -85,7 +85,7 @@ function stage(cwd, {alias}) {
       if (!url) return reject(new Error('Deployment failed'));
       log.info(`> Setting ${url} to alias ${alias}`);
       const aliasProc = exec(now(`alias set ${url} ${alias}`), {cwd});
-      aliasProc.stderr.on('data', (error) => {aliasError = error;});
+      aliasProc.stderr.on('data', (error) => {aliasError = error.replace('\u001b[2K\u001b[G', '');});
       aliasProc.on('close', () => {
         if (aliasError) return reject(new Error(aliasError));
         log.info(`> Alias ready ${alias}`);


### PR DESCRIPTION
Resolves #47, fixes #39, #43 

I've updated the Dockerfile to use the `node:10-alpine` image, and to pull the latest version of `now` with Alpine support (`11.2.1`). I would have pulled `8.3.9` which is what the rest of the code uses, but the binary doesn't seem to work on Alpine at all 🤔

I've tested pretty extensively and it seems to be quite stable ✅

I'd like to make another PR to update `now` version that we pull for `npm` based deployments to `11.2.1`, that way we shouldn't have any compatibility issues from `now` across `npm` and `docker` deployments.