### PR TITLE
Upgrade `now` to 11.2.1

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -4,6 +4,7 @@ const os = require('os');
 const path = require('path');
 const {parse} = require('url');
 const crypto = require('crypto');
+const zlib = require('zlib');
 const {fs} = require('mz');
 const git = require('simple-git/promise')();
 const axios = require('axios');
@@ -45,6 +46,7 @@ function setup() {
       alpine: 'alpine'
     };
 
+    const gunzip = zlib.createGunzip();
     const nowFile = fs.createWriteStream('./now-cli', {encoding: 'binary', flags: 'a', mode: 0o777});
 
     nowFile.on('close', () => {
@@ -56,14 +58,14 @@ function setup() {
       return reject(err);
     });
 
-    const url = `https://github.com/zeit/now-cli/releases/download/${NOW_VERSION}/now-${type[os.platform()]}`;
+    const url = `https://github.com/zeit/now-cli/releases/download/${NOW_VERSION}/now-${type[os.platform()]}.gz`;
 
     axios({
       method: 'get',
       url,
       responseType: 'stream'
     }).then((response) => {
-      response.data.pipe(nowFile);
+      response.data.pipe(gunzip).pipe(nowFile);
     }).catch((error) => {
       return reject(error);
     });

--- a/src/core.js
+++ b/src/core.js
@@ -25,7 +25,7 @@ if (!GITHUB_TOKEN && !GITLAB_TOKEN) throw new Error('GITHUB_TOKEN and/or GITLAB_
 if (!GITHUB_WEBHOOK_SECRET && !GITLAB_WEBHOOK_SECRET) throw new Error('GITHUB_WEBHOOK_SECRET and/or GITLAB_WEBHOOK_SECRET must be defined in environment. Create one at https://github.com/{OWNERNAME}/{REPONAME}/settings/hooks or https://gitlab.com/{OWNERNAME}/{REPONAME}/settings/integration (swap in the path to your repo)');
 if (!ZEIT_API_TOKEN) throw new Error('ZEIT_API_TOKEN must be defined in environment. Create one at https://zeit.co/account/tokens');
 
-if (!NOW_VERSION) NOW_VERSION = '8.3.9';
+if (!NOW_VERSION) NOW_VERSION = '11.2.1';
 
 function setup() {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Follow up to #48 to upgrade `now` to version `11.2.1`.

This also fixes this issue (#45):
```
> Checking out hugomd-patch-1@784ab323c4c226a62c4df30aefaf07451c1bb6f0...
Error: /home/nowuser/src/now-cli: line 1: can't open �: no such file
> Setting GitHub status to "error"...
    at Socket.nowProc.stderr.on (/home/nowuser/src/src/core.js:82:49)
    at emitOne (events.js:121:20)
    at Socket.emit (events.js:211:7)
    at addChunk (_stream_readable.js:263:12)
    at readableAddChunk (_stream_readable.js:246:13)
    at Socket.Readable.push (_stream_readable.js:208:10)
    at Pipe.onread (net.js:597:20)
```

Which I believe is as a result of a change to the environment that deployments typically run on 🕵️‍♂️

✌️